### PR TITLE
simplify .env to not duplicate database connection variables

### DIFF
--- a/.env.circleci
+++ b/.env.circleci
@@ -1,14 +1,11 @@
-# mysql_dev - host and port should match the service name in docker-compose.yml
-DATABASE_HOST=mysql
-DATABASE_PORT=3306
-DATABASE_POOL=5
-
 # shared DB credentials
-DATABASE_NAME_PREFIX=qa_server
-DATABASE_RAILS_USER=cci_user
-DATABASE_RAILS_USER_PW=cci_userpw
-DATABASE_RAILS_ROOT_PW=cci_root
-DATABASE_PORT=3306
+MYSQL_HOST=mysql
+MYSQL_PORT=3306
+MYSQL_POOL=5
+MYSQL_DATABASE_NAME_PREFIX=qa_server
+MYSQL_USER=cci_user
+MYSQL_PASSWORD=cci_userpw
+MYSQL_ROOT_PASSWORD=cci_root
 
 # NOTE: `AUTHORITIES_PATH` is not supported in CCI and that volume in docker-compose.yml
 #       needs to be commented out and replaced with volume `authorities`.

--- a/.env.example
+++ b/.env.example
@@ -1,25 +1,47 @@
-# Rename this file .env.local
-# Add account settings and API keys here specific to the install machine.
+## Rename this to a file ending with `.env` (e.g. `development.env`, `staging.env`, `production.env`)
 
+## --------------------
+## APPLICATION SETTINGS
+## --------------------
+
+## Uncomment the Rails environment that this `.env` file configures
 RAILS_ENV=development
+# RAILS_ENV=staging
+# RAILS_ENV=production
 
-DATABASE_HOST=mysql
-DATABASE_PORT=3306
-DATABASE_NAME_PREFIX=qa_server
-DATABASE_RAILS_USER=CHANGEME
-DATABASE_RAILS_USER_PW=CHANGEME
-DATABASE_RAILS_ROOT_PW=CHANGEME
-DATABASE_POOL=5
-
-DISCOGS_KEY=CHANGEME
-DISCOGS_SECRET=CHANGEME
+## Used to control launch of long-running processes from the browser.
+RELOAD_TOKEN=CHANGEME
 
 MAX_PERFORMANCE_CACHE_SIZE=8MB
-RELOAD_TOKEN=CHANGEME
-AUTHORITIES_PATH=/path/to/files/for/config/authorities
 
-# Values below should reflect DATABASE_ values above.
+## For localhost development, use full path.  For AWS S3, use just `authorities`.
+AUTHORITIES_PATH=/path/to/files/for/config/authorities
+# AUTHORITIES_PATH=authorities
+
+## --------------------
+## AUTHORITY SETTINGS
+## --------------------
+
+## DISCOGS Connection (uncomment and update if connecting to DISCOGS authority)
+# DISCOGS_KEY=CHANGEME
+# DISCOGS_SECRET=CHANGEME
+
+
+## --------------------
+## DATABASE SETTINGS
+## --------------------
+
+## Database Connection
+## Uncomment the MYSQL_DATABASE based on the RAILS_ENV.  Use no postfix version for production.
 MYSQL_DATABASE=qa_server_development
+# MYSQL_DATABASE=qa_server_staging
+# MYSQL_DATABASE=qa_server
+MYSQL_DATABASE_NAME_PREFIX=qa_server
+MYSQL_HOST=mysql
+MYSQL_PORT=3306
+MYSQL_POOL=5
+
+## Database Users
+MYSQL_USER=CHANGEME
 MYSQL_PASSWORD=CHANGEME
 MYSQL_ROOT_PASSWORD=CHANGEME
-MYSQL_USER=CHANGEME

--- a/bin/db-migrate-seed.sh
+++ b/bin/db-migrate-seed.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-db-wait.sh "$DATABASE_HOST:$DATABASE_PORT"
+db-wait.sh "$MYSQL_HOST:$MYSQL_PORT"
 
 bundle exec rails db:migrate
 bundle exec rails db:seed

--- a/bin/db-wait.sh
+++ b/bin/db-wait.sh
@@ -1,14 +1,14 @@
 #! /bin/sh
 
 # Wait for MySQL
-CMD="nc -z -v -w30 $DATABASE_HOST $DATABASE_PORT"
+CMD="nc -z -v -w30 $MYSQL_HOST $MYSQL_PORT"
 echo "-----------------------------------"
 echo " "
 echo "bin/db-wait.sh -- The following command will run to check if MySQL is running..."
 echo "bin/db-wait.sh -- $CMD"
 echo " "
 echo "-----------------------------------"
-until nc -z -v -w30 $DATABASE_HOST $DATABASE_PORT; do
+until nc -z -v -w30 $MYSQL_HOST $MYSQL_PORT; do
  echo 'Waiting for MySQL...'
  sleep 1
 done

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,38 +8,38 @@ default: &default
 
 development:
   <<: *default
-  database: <%= "#{ENV['DATABASE_NAME_PREFIX']}_development" %>
-  username: <%= "#{ENV['DATABASE_RAILS_USER']}" %>
-  password: <%= "#{ENV['DATABASE_RAILS_USER_PW']}" %>
-  host:     <%= "#{ENV['DATABASE_HOST']}" %>
-  pool:     <%= ENV["DATABASE_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
+  database: <%= "#{ENV['MYSQL_DATABASE_NAME_PREFIX']}_development" %>
+  username: <%= "#{ENV['MYSQL_USER']}" %>
+  password: <%= "#{ENV['MYSQL_PASSWORD']}" %>
+  host:     <%= "#{ENV['MYSQL_HOST']}" %>
+  pool:     <%= ENV["MYSQL_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
   timeout: 5000
 
 integration:
   <<: *default
-  database: <%= "#{ENV['DATABASE_NAME_PREFIX']}_integration" %>
-  username: <%= "#{ENV['DATABASE_RAILS_USER']}" %>
-  password: <%= "#{ENV['DATABASE_RAILS_USER_PW']}" %>
-  host:     <%= "#{ENV['DATABASE_HOST']}" %>
-  pool:     <%= ENV["DATABASE_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
+  database: <%= "#{ENV['MYSQL_DATABASE_NAME_PREFIX']}_integration" %>
+  username: <%= "#{ENV['MYSQL_USER']}" %>
+  password: <%= "#{ENV['MYSQL_PASSWORD']}" %>
+  host:     <%= "#{ENV['MYSQL_HOST']}" %>
+  pool:     <%= ENV["MYSQL_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
   timeout: 5000
 
 staging:
   <<: *default
-  database: <%= "#{ENV['DATABASE_NAME_PREFIX']}_staging" %>
-  username: <%= "#{ENV['DATABASE_RAILS_USER']}" %>
-  password: <%= "#{ENV['DATABASE_RAILS_USER_PW']}" %>
-  host:     <%= "#{ENV['DATABASE_HOST']}" %>
-  pool:     <%= ENV["DATABASE_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
+  database: <%= "#{ENV['MYSQL_DATABASE_NAME_PREFIX']}_staging" %>
+  username: <%= "#{ENV['MYSQL_USER']}" %>
+  password: <%= "#{ENV['MYSQL_PASSWORD']}" %>
+  host:     <%= "#{ENV['MYSQL_HOST']}" %>
+  pool:     <%= ENV["MYSQL_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
   timeout: 5000
 
 production:
   <<: *default
-  database: <%= "#{ENV['DATABASE_NAME_PREFIX']}" %>
-  username: <%= "#{ENV['DATABASE_RAILS_USER']}" %>
-  password: <%= "#{ENV['DATABASE_RAILS_USER_PW']}" %>
-  host:     <%= "#{ENV['DATABASE_HOST']}" %>
-  pool:     <%= ENV["DATABASE_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
+  database: <%= "#{ENV['MYSQL_DATABASE_NAME_PREFIX']}" %>
+  username: <%= "#{ENV['MYSQL_USER']}" %>
+  password: <%= "#{ENV['MYSQL_PASSWORD']}" %>
+  host:     <%= "#{ENV['MYSQL_HOST']}" %>
+  pool:     <%= ENV["MYSQL_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
   timeout: 5000
 
 test:

--- a/config/database_SQL.yml
+++ b/config/database_SQL.yml
@@ -8,38 +8,38 @@ default: &default
 
 development:
   <<: *default
-  database: <%= "#{ENV['DATABASE_NAME_PREFIX']}_development" %>
-  username: <%= "#{ENV['DATABASE_RAILS_USER']}" %>
-  password: <%= "#{ENV['DATABASE_RAILS_USER_PW']}" %>
-  host:     <%= "#{ENV['DATABASE_HOST']}" %>
-  pool:     <%= ENV["DATABASE_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
+  database: <%= "#{ENV['MYSQL_DATABASE_NAME_PREFIX']}_development" %>
+  username: <%= "#{ENV['MYSQL_USER']}" %>
+  password: <%= "#{ENV['MYSQL_PASSWORD']}" %>
+  host:     <%= "#{ENV['MYSQL_HOST']}" %>
+  pool:     <%= ENV["MYSQL_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
   timeout: 5000
 
 integration:
   <<: *default
-  database: <%= "#{ENV['DATABASE_NAME_PREFIX']}_integration" %>
-  username: <%= "#{ENV['DATABASE_RAILS_USER']}" %>
-  password: <%= "#{ENV['DATABASE_RAILS_USER_PW']}" %>
-  host:     <%= "#{ENV['DATABASE_HOST']}" %>
-  pool:     <%= ENV["DATABASE_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
+  database: <%= "#{ENV['MYSQL_DATABASE_NAME_PREFIX']}_integration" %>
+  username: <%= "#{ENV['MYSQL_USER']}" %>
+  password: <%= "#{ENV['MYSQL_PASSWORD']}" %>
+  host:     <%= "#{ENV['MYSQL_HOST']}" %>
+  pool:     <%= ENV["MYSQL_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
   timeout: 5000
 
 staging:
   <<: *default
-  database: <%= "#{ENV['DATABASE_NAME_PREFIX']}_staging" %>
-  username: <%= "#{ENV['DATABASE_RAILS_USER']}" %>
-  password: <%= "#{ENV['DATABASE_RAILS_USER_PW']}" %>
-  host:     <%= "#{ENV['DATABASE_HOST']}" %>
-  pool:     <%= ENV["DATABASE_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
+  database: <%= "#{ENV['MYSQL_DATABASE_NAME_PREFIX']}_staging" %>
+  username: <%= "#{ENV['MYSQL_USER']}" %>
+  password: <%= "#{ENV['MYSQL_PASSWORD']}" %>
+  host:     <%= "#{ENV['MYSQL_HOST']}" %>
+  pool:     <%= ENV["MYSQL_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
   timeout: 5000
 
 production:
   <<: *default
-  database: <%= "#{ENV['DATABASE_NAME_PREFIX']}" %>
-  username: <%= "#{ENV['DATABASE_RAILS_USER']}" %>
-  password: <%= "#{ENV['DATABASE_RAILS_USER_PW']}" %>
-  host:     <%= "#{ENV['DATABASE_HOST']}" %>
-  pool:     <%= ENV["DATABASE_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
+  database: <%= "#{ENV['MYSQL_DATABASE_NAME_PREFIX']}" %>
+  username: <%= "#{ENV['MYSQL_USER']}" %>
+  password: <%= "#{ENV['MYSQL_PASSWORD']}" %>
+  host:     <%= "#{ENV['MYSQL_HOST']}" %>
+  pool:     <%= ENV["MYSQL_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
   timeout: 5000
 
 test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,12 +32,12 @@ services:
     restart: always
     container_name: ld4p-qa_server-mysql
     environment:
-      - MYSQL_ROOT_PASSWORD=${DATABASE_RAILS_ROOT_PW}
-      - MYSQL_DATABASE=${DATABASE_NAME_PREFIX}_development
-      - MYSQL_USER=${DATABASE_RAILS_USER}
-      - MYSQL_PASSWORD=${DATABASE_RAILS_USER_PW}
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_DATABASE=${MYSQL_DATABASE_NAME_PREFIX}_development
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
     ports:
-      - "${DATABASE_PORT}:3306"
+      - "${MYSQL_PORT}:3306"
     volumes:
       - db-mysql-data:/var/lib/mysql/data
 


### PR DESCRIPTION
Fixes #50

Uses env names required for mariadb.