### PR TITLE
Bump qa_server to 8.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 # Required gems for QA and linked data access
 # NOTE: We need to update the published RubyGems version of qa_server with the 8.0 release. Until
 # then, the next entry is set to use the GitHub repo and tag instead.
-gem 'qa_server', git: 'https://github.com/LD4P/qa_server.git', tag: 'v8.0'
+gem 'qa_server', git: 'https://github.com/LD4P/qa_server.git', tag: 'v8.0.1'
 gem 'qa', '~> 5.10'
 gem 'linkeddata'
 gem 'psych', '~> 5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/LD4P/qa_server.git
-  revision: af1f6509919b07b188a4714937aa33456614bf57
-  tag: v8.0
+  revision: e3ca6e238ec2630a5bfdd92ddc2ff2b906f964c4
+  tag: v8.0.1
   specs:
-    qa_server (8.0.0)
+    qa_server (8.0.1)
       gruff
       rails (~> 7.0)
       sass-rails (~> 5.0)


### PR DESCRIPTION
Fixes linked data lookups ArgumentError due to ruby 3 differences in handling positional and keyword arguments