### PR TITLE
Just return term list in wikidata search response

### DIFF
--- a/app/authorities/qa/authorities/wikidata/generic_authority.rb
+++ b/app/authorities/qa/authorities/wikidata/generic_authority.rb
@@ -58,18 +58,9 @@ module Qa::Authorities
     # @note WARNING: If this is moved to QA, it should NOT return json with results: and response_header: keys
     #                unless code is put in place to process a request for the response_header data.
     def parse_authority_response(raw_response)
-      formatted_response = raw_response['search'].map do |doc|
+      raw_response['search'].map do |doc|
         { id: doc['id'], uri: doc['concepturi'], label: doc['label'], context: extended_context(doc) }
       end
-      {
-        results: formatted_response,
-        response_header: {
-          start_record: 1,
-          requested_records: "UNKNOWN",
-          retrieved_records: raw_response.count,
-          total_records: "UNKNOWN"
-        }
-      }
     end
 
     def extended_context(doc)


### PR DESCRIPTION
Fixes output of #parse_authority_response so that it returns what seems to be the format needed by TermsController for displaying the actual response (compared it to response from the loc endpoint).

Example of working wikidata search endpoint:
https://lookup-int.ld4l.org/authorities/search/wikidata/item?q=time

Example of broken wikidata search endpoint:
https://lookup.ld4l.org/authorities/search/wikidata/item?q=time